### PR TITLE
修复python3.8运行环境下的执行问题

### DIFF
--- a/cobra/pickup.py
+++ b/cobra/pickup.py
@@ -176,7 +176,13 @@ class Directory(object):
     """
 
     def collect_files(self):
-        t1 = time.clock()
+
+        version = sys.version
+
+        if version[:3] == '3.7':
+            t1 = time.clock()
+        else:
+            t1 = time.perf_counter()
         self.files(self.absolute_path)
         self.result['no_extension'] = {'count': 0, 'list': []}
         for extension, values in self.type_nums.items():
@@ -197,7 +203,10 @@ class Directory(object):
                     self.result['no_extension']['list'].append(f)
         if self.result['no_extension']['count'] == 0:
             del self.result['no_extension']
-        t2 = time.clock()
+        if version[:3] == "3.7":
+            t2 = time.clock()
+        else:
+            t2 = time.perf_counter()
         # reverse list count
         self.result = sorted(self.result.items(), key=lambda t: t[0], reverse=False)
         return self.result, self.file_sum, t2 - t1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ requests==2.20.0
 pytest==3.0.6
 pip==9.0.1
 phply==1.0.0
-Werkzeug==0.15.3
+Werkzeug==0.15.5
 ConcurrentLogHandler==0.9.1

--- a/tests/test_pickup.py
+++ b/tests/test_pickup.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+"""
+    tests.pickup
+    ~~~~~~~~~~~~
+
+    Tests cobra.pickup
+
+    :author:    banbooboo <1798736436@qq.com>
+    :homepage:  https://github.com/WhaleShark-Team/cobra
+    :license:   MIT, see LICENSE for more details.
+    :copyright: Copyright (c) 2018 Feei. All rights reserved
+"""
+
+from cobra.pickup import Directory
+import os
+
+def test_vulnerabilities():
+
+
+    dt =Directory(os.path.dirname(__file__)+"/vulnerabilities")
+
+    assert dt.collect_files()


### PR DESCRIPTION
### 报告问题：
运行环境为：python3.8，mac10.14.6 版本。
运行命令python cobra.py -t tests/vulnerabilities时，报错两个问题。
1.TypeError: required field “type_ignores“ missing from Module
2. “pickup.py", line 183。AttributeError: module 'time' has no attribute 'clock'

提交测试用例为tests/test_pickup.py



